### PR TITLE
Add Dakera — persistent memory layer for RAG agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 - [RAGFlow](https://github.com/infiniflow/ragflow)
 - [RAG-Anything](https://github.com/HKUDS/RAG-Anything)
 - [Awesome-LLM-RAG](https://github.com/jxzhangjhu/Awesome-LLM-RAG)
-- [Dakera](https://github.com/Dakera-AI/dakera) — Persistent memory layer for RAG agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay
+- [Dakera](https://github.com/dakera-ai/dakera-deploy) — Persistent memory layer for RAG agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay
 
 
 ## 🔥Latest Papers

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - [RAGFlow](https://github.com/infiniflow/ragflow)
 - [RAG-Anything](https://github.com/HKUDS/RAG-Anything)
 - [Awesome-LLM-RAG](https://github.com/jxzhangjhu/Awesome-LLM-RAG)
+- [Dakera](https://github.com/Dakera-AI/dakera) — Persistent memory layer for RAG agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay
 
 
 ## 🔥Latest Papers


### PR DESCRIPTION
## Add Dakera to Project section

[Dakera](https://github.com/Dakera-AI/dakera) is a persistent memory layer for RAG agents — added to the Project section alongside LightRAG, RAGFlow, and RAG-Anything.

**What Dakera adds to the RAG ecosystem:**
- Hybrid BM25 + vector retrieval: combines keyword precision with semantic similarity for better recall
- Temporal reasoning: handles time-relative queries natively ("what was discussed last week?")
- Importance-weighted memory decay: noise fades while relevant memories persist
- Multi-tenant namespacing: isolated retrieval contexts per user/agent

pip install dakera
