### PR TITLE
Add Dakera — persistent memory layer for RAG agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - [RAGFlow](https://github.com/infiniflow/ragflow)
 - [RAG-Anything](https://github.com/HKUDS/RAG-Anything)
 - [Awesome-LLM-RAG](https://github.com/jxzhangjhu/Awesome-LLM-RAG)
+- [Dakera](https://github.com/dakera-ai/dakera-deploy) — Persistent memory layer for RAG agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay
 
 
 ## 🔥Latest Papers


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/dakera-ai/dakera-deploy) — a production-ready, self-hosted agent memory server.

**Key features:**
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall (importance fades over time, like human memory)
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Open-source (Apache 2.0), self-hosted, production-ready.
