### PR TITLE
Add code link to QuCo-RAG entry + create ACL 2026 Findings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@
 - Dec 27 [DICE: Discrete Interpretable Comparative Evaluation with Probabilistic Scoring for Retrieval-Augmented Generation](https://arxiv.org/pdf/2512.22629)
 - Dec 27 [HiFi-RAG: Hierarchical Content Filtering and Two-Pass Generation for Open-Domain RAG](https://arxiv.org/pdf/2512.22442)
 - Dec 25 [FVA-RAG: Falsification-Verification Alignment for Mitigating Sycophantic Hallucinations](https://arxiv.org/pdf/2512.07015)
-- Dec 22 [QuCo-RAG: Quantifying Uncertainty from the Pre-training Corpus for Dynamic Retrieval-Augmented Generation](https://arxiv.org/pdf/2512.19134)
+- Dec 22 [QuCo-RAG: Quantifying Uncertainty from the Pre-training Corpus for Dynamic Retrieval-Augmented Generation](https://arxiv.org/pdf/2512.19134) [\[Code\]](https://github.com/ZhishanQ/QuCo-RAG)
 - Dec 20 [Bidirectional RAG: Safe Self-Improving Retrieval-Augmented Generation Through Multi-Stage Validation](https://arxiv.org/pdf/2512.22199)
 - Dec 19 [MMRAG-RFT: Two-stage Reinforcement Fine-tuning for Explainable Multi-modal Retrieval-augmented Generation](https://arxiv.org/pdf/2512.17194)
 - Dec 17 [The Semantic Illusion: Certified Limits of Embedding-Based Hallucination Detection in RAG Systems](https://arxiv.org/pdf/2512.15068)
@@ -398,6 +398,13 @@
 - Jun 5 [Knowledgeable-r1: Policy Optimization for Knowledge Exploration in Retrieval-Augmented Generation](https://arxiv.org/pdf/2506.05154v1)
 - Jun 4 [R-Search: Empowering LLM Reasoning with Search via Multi-Reward Reinforcement Learning](https://arxiv.org/pdf/2506.04185v1)
 - Jun 2 [ImpRAG: Retrieval-Augmented Generation with Implicit Queries](https://arxiv.org/pdf/2506.02279)
+
+
+### 🥇ACL 2026
+$fingdings$  
+
+- [QuCo-RAG: Quantifying Uncertainty from the Pre-training Corpus for Dynamic Retrieval-Augmented Generation](https://arxiv.org/pdf/2512.19134) [\[Code\]](https://github.com/ZhishanQ/QuCo-RAG)
+
 
 
 ### 🥇ACL 2025


### PR DESCRIPTION
Hi @liunian-Jay — thanks for already adding **QuCo-RAG** to the December 2025 list! Two small additions in this PR:

### Changes

1. **Add `[Code]` link** to the existing Dec 22 QuCo-RAG entry (line 238), pointing to the official implementation: https://github.com/ZhishanQ/QuCo-RAG

2. **Create new `### 🥇ACL 2026` section** with a `$fingdings$` subsection (matching the existing ACL 2025 styling, including the same suffix you used). The paper has been accepted to **Findings of ACL 2026**. Only QuCo-RAG is added for now; more entries can be appended as ACL 2026 papers become available.

### About the paper

QuCo-RAG (ACL Findings 2026) is a dynamic RAG method that quantifies uncertainty using objective pre-training-corpus statistics (via Infini-gram over 4T tokens) instead of model-internal signals like logits/entropy:
- **Pre-generation:** detects low-frequency entities → long-tail knowledge gaps
- **Runtime:** verifies entity co-occurrence in pre-training corpus → zero co-occurrence flags hallucination risk

Reduces hallucinations on multi-hop QA (HotpotQA, 2WikiMultihopQA): **+5–12 EM** on OLMo-2 (7B/13B/32B) and **up to +14 EM** on Llama-3 / Qwen2.5 / GPT-4.1 / GPT-5-chat. Also generalizes to ASQA (long-form) and PubMedQA (biomedical).

- Paper: https://arxiv.org/abs/2512.19134
- Code:  https://github.com/ZhishanQ/QuCo-RAG

Closely related to your existing entry *"Modeling Uncertainty Trends for Timely Retrieval in Dynamic RAG"* (Nov 13, 2025) — happy to adjust placement or formatting if you prefer something different. Thanks!